### PR TITLE
Alfa updates

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
@@ -23,7 +23,6 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.type.CollectionType;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -184,9 +183,12 @@ public final class Collections {
 		// who set up circular or shared references between/to collections.
 		if ( ce.isReached() ) {
 			// We've been here before
-			throw new HibernateException(
-					"Found shared references to a collection: " + type.getRole()
-			);
+
+			// Alfa change - ignore shared collections, these are deliberate and there will be no changes within them.
+			return;
+//			throw new HibernateException(
+//					"Found shared references to a collection: " + type.getRole()
+//			);
 		}
 
 		ce.setReached( true );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -14,8 +14,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Objects;
+import java.util.Properties;
+
 import javax.persistence.AttributeConverter;
 
 import org.hibernate.FetchMode;
@@ -52,13 +53,9 @@ import org.hibernate.type.descriptor.JdbcTypeNameMapper;
 import org.hibernate.type.descriptor.converter.AttributeConverterSqlTypeDescriptorAdapter;
 import org.hibernate.type.descriptor.converter.AttributeConverterTypeAdapter;
 import org.hibernate.type.descriptor.java.BasicJavaDescriptor;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
-import org.hibernate.type.descriptor.spi.JdbcRecommendedSqlTypeMappingContext;
-import org.hibernate.type.descriptor.sql.JdbcTypeJavaClassMappings;
 import org.hibernate.type.descriptor.sql.LobTypeMappings;
 import org.hibernate.type.descriptor.sql.NationalizedTypeMappings;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
-import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.DynamicParameterizedType;
 
 /**
@@ -512,7 +509,8 @@ public class SimpleValue implements KeyValue {
 			throw new MappingException( msg );
 		}
 
-		return type = result;
+		// Alfa change - don't set the type as a side-effect.  This prevents AlfaStringType being set as the type for String columns.
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
- ignore shared collections, these are deliberate and there will be no changes within them (same as Alfa change in 5.4.19)
- don't set the type as a side-effect of getType() method on SimpleValue (mimics behaviour of 5.4)