### PR TITLE
HHH-19089 lower collection pre-sizing

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
@@ -35,10 +35,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 
 	/**
-	 * Let's be reasonable, a row estimate greater than 1M rows is probably either a mis-estimation or bug,
-	 * so let's set 2^20 which is a bit above 1M as maximum collection size.
+	 * Let's be reasonable, a row estimate greater than 8k rows is probably either a mis-estimation or bug,
+	 * so let's set 2^13 which is a bit above 8k as maximum collection size.
 	 */
-	private static final int INITIAL_COLLECTION_SIZE_LIMIT = 1 << 20;
+	private static final int INITIAL_COLLECTION_SIZE_LIMIT = 1 << 13;
 
 	private static final ListResultsConsumer<?> NEVER_DE_DUP_CONSUMER = new ListResultsConsumer<>( UniqueSemantic.NEVER );
 	private static final ListResultsConsumer<?> ALLOW_DE_DUP_CONSUMER = new ListResultsConsumer<>( UniqueSemantic.ALLOW );


### PR DESCRIPTION
Backport of upstream commit 207a3637 onto the 6.6 branch.

Lowers INITIAL_COLLECTION_SIZE_LIMIT from 1 << 20 (~1M) to 1 << 13 (~8k) to prevent heap usage peaks and
  GC pressure when callers pass very large setMaxResults values (e.g. Integer.MAX_VALUE).

Comment text retained in 6.6 style; only the numeric values updated.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
